### PR TITLE
Fix: renamed citation_signal to citations_signal to fix AttributeError

### DIFF
--- a/src/chat_lm_studio.py
+++ b/src/chat_lm_studio.py
@@ -21,7 +21,7 @@ class LMStudioSignals(QObject):
     response_signal = Signal(str)
     error_signal = Signal(str)
     finished_signal = Signal()
-    citation_signal = Signal(str)
+    citations_signal = Signal(str)
 
 class LMStudioChat:
     def __init__(self):


### PR DESCRIPTION
### Problem

An `AttributeError` was raised when submitting a question in the GUI due to the signal `citations_signal` being referenced but not defined in the `LMStudioSignals` class.

### Solution

Renamed `citation_signal` to `citations_signal` in `chat_lm_studio.py` to match the name used in `gui_tabs_database_query.py`.

### Testing

Tested locally on Windows:
- No more error on submit
- Citations are correctly emitted and displayed

This fix ensures proper signal communication between LMStudio backend and the GUI.
