### PR TITLE
Add MiniMax-M3 to model list and set as default

### DIFF
--- a/chat/minimax.py
+++ b/chat/minimax.py
@@ -8,7 +8,7 @@ from core.utilities import format_citations
 from core.constants import system_message, PROJECT_ROOT
 
 MINIMAX_BASE_URL = "https://api.minimax.io/v1"
-MINIMAX_MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+MINIMAX_MODELS = ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
 # Temperature must be in (0.0, 1.0] for MiniMax
 _MINIMAX_MIN_TEMP = 0.01
 
@@ -26,7 +26,7 @@ class MiniMaxChat:
 
     def connect_to_minimax(self, augmented_query):
         minimax_config = self.config.get('minimax', {})
-        model = minimax_config.get('model', 'MiniMax-M2.7')
+        model = minimax_config.get('model', 'MiniMax-M3')
         api_key = minimax_config.get('api_key')
 
         if not api_key:

--- a/core/config.py
+++ b/core/config.py
@@ -14,7 +14,7 @@ class OpenAIConfig(BaseModel):
 
 class MiniMaxConfig(BaseModel):
     api_key: Optional[str] = None
-    model: str = "MiniMax-M2.7"
+    model: str = "MiniMax-M3"
 
 
 class ServerConfig(BaseModel):

--- a/gui/tabs_databases/query.py
+++ b/gui/tabs_databases/query.py
@@ -289,6 +289,7 @@ class DatabaseQueryTab(QWidget):
             "Kobold",
             "LM Studio",
             "ChatGPT",
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ])
@@ -398,6 +399,7 @@ class DatabaseQueryTab(QWidget):
             "LM Studio": LMStudioStrategy(self),
             "Kobold": KoboldStrategy(self),
             "ChatGPT": ChatGPTStrategy(self),
+            "MiniMax-M3": MiniMaxStrategy(self),
             "MiniMax-M2.7": MiniMaxStrategy(self),
             "MiniMax-M2.7-highspeed": MiniMaxStrategy(self),
         }

--- a/setup_windows.py
+++ b/setup_windows.py
@@ -317,7 +317,7 @@ def update_config_yaml():
     if 'api_key' not in config['minimax']:
         config['minimax']['api_key'] = None
     if 'model' not in config['minimax']:
-        config['minimax']['model'] = 'MiniMax-M2.7'
+        config['minimax']['model'] = 'MiniMax-M3'
 
     with open(config_path, 'w', encoding='utf-8') as file:
         yaml.dump(config, file, default_flow_style=False)


### PR DESCRIPTION
## Summary
Adds `MiniMax-M3` as the latest MiniMax model option and makes it the default for new configurations. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` (both added in #475) remain available so existing users on those models are not disrupted.

## Changes
- `chat/minimax.py`: add `MiniMax-M3` to `MINIMAX_MODELS` (first entry); change in-code default fallback to `MiniMax-M3`
- `core/config.py`: `MiniMaxConfig.model` default changed to `MiniMax-M3`
- `setup_windows.py`: config.yaml seed value for `minimax.model` changed to `MiniMax-M3`
- `gui/tabs_databases/query.py`: add `MiniMax-M3` to the Query Database backend selector and to the `_strategy_for_source` map (reuses the existing `MiniMaxStrategy`)

## Notes
- No API URL, temperature, or request shape changes — M3 is served by the same OpenAI-compatible endpoint (`https://api.minimax.io/v1`) that M2.7 already uses, so the existing `MiniMaxStrategy` / `MiniMaxThread` works as-is.
- Existing `config.yaml` files keep whatever model the user previously selected; the M3 default only applies to fresh installs.