### PR TITLE
Add optional TwelveLabs video ingestion (Pegasus video analysis + Marengo embeddings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ python gui.py
 
 |                |                                                                                                                                                                                                          |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 📂 **Ingest**  | 📄 `.pdf`, `.docx`, `.txt`, `.html`, `.htm`, `.md`, `.csv`, `.xls`, `.xlsx`, `.xlsm`, `.rtf`, `.eml`, `.msg`  <br> 🖼️ `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`, `.tif`, `.tiff`  <br> 🎵 `.mp3`, `.wav`, `.m4a`, `.ogg`, `.wma`, `.flac` |
-| ⚙️ **Process** | 📝 Extract text from documents  <br> 🖼️ Generate descriptions from images  <br> 🎧 Transcribe speech from audio                                                                                         |
+| 📂 **Ingest**  | 📄 `.pdf`, `.docx`, `.txt`, `.html`, `.htm`, `.md`, `.csv`, `.xls`, `.xlsx`, `.xlsm`, `.rtf`, `.eml`, `.msg`  <br> 🖼️ `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`, `.tif`, `.tiff`  <br> 🎵 `.mp3`, `.wav`, `.m4a`, `.ogg`, `.wma`, `.flac`  <br> 🎬 video (optional, via [TwelveLabs](#optional-video-understanding-with-twelvelabs)) |
+| ⚙️ **Process** | 📝 Extract text from documents  <br> 🖼️ Generate descriptions from images  <br> 🎧 Transcribe speech from audio  <br> 🎬 Describe video with TwelveLabs Pegasus (optional)                                  |
 | 🧠 **Store**   | All processed content is embedded and saved into the vector database for searching.                                                                                                              |
 
 ### Query → LLM → Output
@@ -80,6 +80,41 @@ python gui.py
 
 > [!NOTE]
 > Instructions on how to use the program are being consolidated into the `Ask Jeeves` functionality, which can be accessed from the "Ask Jeeves" menu option.  Please create an issue if Jeeves is not working.
+
+<a name="optional-video-understanding-with-twelvelabs"></a>
+<div align="center"> <h2>Optional: Video understanding with TwelveLabs</h2></div>
+
+Audio files are transcribed locally with Whisper, but full **video** understanding
+(visuals + speech + on-screen text) is available as an *opt-in* cloud backend via
+[TwelveLabs](https://twelvelabs.io). It is off by default and changes nothing about
+the existing local pipeline.
+
+- **Pegasus** analyzes a video and produces a rich text description, which is written
+  to `Docs_for_DB` in the same `{page_content, metadata}` shape as a transcript, so it
+  flows through the normal chunk → embed → store → search pipeline.
+- **Marengo** produces 512‑dim multimodal embeddings for video and text, for callers
+  that want to embed video directly instead of going through a description.
+
+Set your key in `config.yaml`:
+
+```yaml
+twelvelabs:
+  api_key: "tlk_..."        # or set the TWELVELABS_API_KEY environment variable
+  pegasus_model: pegasus1.5
+  marengo_model: marengo3.0
+```
+
+Then ingest a video by URL:
+
+```python
+from modules.twelvelabs_video import TwelveLabsVideoProcessor
+
+TwelveLabsVideoProcessor().start_transcription_process(
+    "https://example.com/clips/talk.mp4"
+)  # writes Docs_for_DB/talk.json, ready for the vector database
+```
+
+You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
 
 <a name="request-a-feature-or-report-a-bug"></a>
 

--- a/core/config.py
+++ b/core/config.py
@@ -21,6 +21,12 @@ class MiniMaxConfig(_SubConfig):
     model: str = "MiniMax-M3"
 
 
+class TwelveLabsConfig(_SubConfig):
+    api_key: Optional[str] = None
+    pegasus_model: str = "pegasus1.5"
+    marengo_model: str = "marengo3.0"
+
+
 class ServerConfig(_SubConfig):
     api_key: str = ""
     connection_str: str = "http://127.0.0.1:1234/v1"
@@ -105,6 +111,7 @@ class AppConfig(BaseSettings):
 
     openai: OpenAIConfig = Field(default_factory=OpenAIConfig)
     minimax: MiniMaxConfig = Field(default_factory=MiniMaxConfig)
+    twelvelabs: TwelveLabsConfig = Field(default_factory=TwelveLabsConfig)
     server: ServerConfig = Field(default_factory=ServerConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     Compute_Device: ComputeDeviceConfig = Field(default_factory=ComputeDeviceConfig)

--- a/core/constants.py
+++ b/core/constants.py
@@ -804,6 +804,7 @@ libs = [
     # and safetensors>=0.4.3. The jump to 5.x (5.9.0) requires huggingface-hub>=1.5.0 -> full hub-1.x migration +
     # new CLI deps (typer/shellingham/annotated-doc) + v5 breaking API changes. Revisit 5.x as a deliberate migration.
     "transformers==4.57.6",
+    "twelvelabs==1.2.8",  # optional cloud backend: Pegasus video analysis + Marengo embeddings (modules/twelvelabs_video.py)
     "typing-inspection==0.4.2",
     "typing_extensions==4.15.0",
     "unstructured-client==0.44.1",

--- a/modules/twelvelabs_video.py
+++ b/modules/twelvelabs_video.py
@@ -1,0 +1,161 @@
+"""TwelveLabs video ingestion.
+
+Adds *video* files to the vector database, mirroring how ``modules/transcribe.py``
+adds audio.  Whisper turns speech into text; here TwelveLabs Pegasus turns the
+*whole* video (visuals + audio + on-screen text) into a description, and that
+description is written to ``Docs_for_DB`` as a ``{page_content, metadata}`` JSON
+- the exact shape ``CreateVectorDB.load_audio_documents`` already consumes, so
+the rest of the pipeline (chunk -> embed -> store -> search) needs no changes.
+
+The optional ``marengo_video_embedding`` helper returns TwelveLabs Marengo's
+512-dim multimodal embedding for a video segment, for callers that want to embed
+video directly rather than going through a text description.
+
+This is an opt-in cloud backend: it requires a TwelveLabs API key and changes no
+default behavior.  Get a free key at https://twelvelabs.io.
+"""
+import json
+import os
+from pathlib import Path
+
+from twelvelabs import TwelveLabs
+from twelvelabs.types.video_context import VideoContext_Url
+
+from core.config import get_config
+from core.constants import PROJECT_ROOT
+
+# Pegasus = video understanding/analysis; Marengo = multimodal embeddings (512-dim).
+PEGASUS_MODEL = "pegasus1.5"
+MARENGO_MODEL = "marengo3.0"
+MARENGO_DIM = 512
+
+DEFAULT_PROMPT = (
+    "Describe this video in detail. Cover what is shown visually, what is said "
+    "or heard, any on-screen text, and the overall topic, so the description can "
+    "answer questions about the video."
+)
+DEFAULT_MAX_TOKENS = 2048
+
+DOCS_DIR = PROJECT_ROOT / "Docs_for_DB"
+
+
+def _resolve_api_key(api_key=None):
+    """Config ``twelvelabs.api_key`` first, then the TWELVELABS_API_KEY env var."""
+    if api_key:
+        return api_key
+    try:
+        cfg = getattr(get_config(), "twelvelabs", None)
+    except Exception:
+        cfg = None
+    if cfg is not None:
+        # AppConfig sub-sections are pydantic models; fall back to dict access too.
+        key = getattr(cfg, "api_key", None) or (cfg.get("api_key") if isinstance(cfg, dict) else None)
+        if key:
+            return key
+    return os.environ.get("TWELVELABS_API_KEY")
+
+
+class TwelveLabsVideoProcessor:
+    """Analyze a video with Pegasus and write a vector-DB document.
+
+    Parameters mirror ``WhisperTranscriber``: construct, then call
+    ``start_transcription_process(video)`` with a public video URL.
+    Unlike Whisper, TwelveLabs runs server-side, so ``video`` is a URL the
+    TwelveLabs API can fetch (not a local path).
+    """
+
+    def __init__(self, api_key=None, model=PEGASUS_MODEL, prompt=DEFAULT_PROMPT,
+                 max_tokens=DEFAULT_MAX_TOKENS):
+        key = _resolve_api_key(api_key)
+        if not key:
+            raise ValueError(
+                "TwelveLabs API key not found. Set it in config.yaml under "
+                "'twelvelabs: api_key:' or via the TWELVELABS_API_KEY environment "
+                "variable. Get a free key at https://twelvelabs.io."
+            )
+        self.client = TwelveLabs(api_key=key)
+        self.model = model
+        self.prompt = prompt
+        self.max_tokens = max_tokens
+
+    def analyze(self, video_url):
+        """Return Pegasus's text analysis of the video at ``video_url``."""
+        response = self.client.analyze(
+            model_name=self.model,
+            video=VideoContext_Url(url=video_url),
+            prompt=self.prompt,
+            max_tokens=self.max_tokens,
+        )
+        return (response.data or "").strip()
+
+    def start_transcription_process(self, video_url, name=None):
+        """Analyze ``video_url`` and write ``Docs_for_DB/<name>.json``.
+
+        ``name`` defaults to the URL's filename stem; returns the JSON path.
+        """
+        text = self.analyze(video_url)
+        if not text:
+            raise RuntimeError("TwelveLabs returned an empty analysis for the video.")
+        return self._create_document_object(text, video_url, name)
+
+    def _create_document_object(self, text, video_url, name=None):
+        DOCS_DIR.mkdir(parents=True, exist_ok=True)
+
+        if name is None:
+            name = Path(video_url.split("?", 1)[0]).stem or "video"
+
+        # No local file to stat (the video lives at a remote URL), so build
+        # metadata directly rather than via extract_typed_metadata(path, ...).
+        metadata = {
+            "file_path": video_url,
+            "file_name": Path(video_url.split("?", 1)[0]).name or name,
+            "file_type": Path(video_url.split("?", 1)[0]).suffix or ".mp4",
+            "document_type": "video",
+            "source": "twelvelabs",
+            "model": self.model,
+        }
+
+        doc_dict = {"page_content": text, "metadata": metadata}
+        json_path = DOCS_DIR / f"{name}.json"
+        json_path.write_text(json.dumps(doc_dict, indent=4), encoding="utf-8")
+        return json_path
+
+
+def marengo_video_embedding(video_url, api_key=None, model=MARENGO_MODEL):
+    """Return Marengo's 512-dim embedding for the video at ``video_url``.
+
+    The video segments are embedded; the first segment's vector is returned
+    (use the SDK directly for per-segment vectors).
+    """
+    key = _resolve_api_key(api_key)
+    if not key:
+        raise ValueError(
+            "TwelveLabs API key not found. Set it in config.yaml under "
+            "'twelvelabs: api_key:' or via the TWELVELABS_API_KEY environment variable."
+        )
+    client = TwelveLabs(api_key=key)
+    task = client.embed.tasks.create(
+        model_name=model,
+        video_url=video_url,
+    )
+    task = client.embed.tasks.wait_for_done(task_id=task.id)
+    result = client.embed.tasks.retrieve(task_id=task.id)
+    segments = result.video_embedding.segments
+    return segments[0].float_
+
+
+def marengo_text_embedding(text, api_key=None, model=MARENGO_MODEL):
+    """Return Marengo's 512-dim embedding for a text query.
+
+    Useful for searching a Marengo-embedded video index with a text query in
+    the same 512-dim multimodal space.
+    """
+    key = _resolve_api_key(api_key)
+    if not key:
+        raise ValueError(
+            "TwelveLabs API key not found. Set it in config.yaml under "
+            "'twelvelabs: api_key:' or via the TWELVELABS_API_KEY environment variable."
+        )
+    client = TwelveLabs(api_key=key)
+    response = client.embed.create(model_name=model, text=text)
+    return response.text_embedding.segments[0].float_


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds **optional video understanding** to VectorDB-Plugin via [TwelveLabs](https://twelvelabs.io). Today the plugin transcribes audio locally with Whisper, but there's no way to ingest *video* (visuals + speech + on-screen text). This adds that as an opt-in cloud backend.

### What it adds
- `modules/twelvelabs_video.py`:
  - `TwelveLabsVideoProcessor` — uses **Pegasus** to analyze a video and write a description to `Docs_for_DB/<name>.json` in the exact `{page_content, metadata}` shape that `CreateVectorDB.load_audio_documents` already consumes. So a video flows through the existing chunk → embed → store → search pipeline with **no pipeline changes** — it mirrors `modules/transcribe.py`.
  - `marengo_video_embedding` / `marengo_text_embedding` — **Marengo** 512-dim multimodal embeddings for callers who want to embed video (or a text query) directly in the same space.
- `core/config.py`: a new `twelvelabs` config section (`api_key`, `pegasus_model`, `marengo_model`), following the existing `openai`/`minimax` pattern. Falls back to the `TWELVELABS_API_KEY` env var.
- `core/constants.py`: pins `twelvelabs==1.2.8` in `libs`.
- `README.md`: documents the feature and adds video to the ingest table.

### Why it helps
RAG over video is a common ask, and the description-as-document approach means video answers show up alongside your existing documents/audio with zero query-side changes.

### Opt-in / non-breaking
Off by default — it does nothing unless a TwelveLabs API key is configured, and it changes no existing defaults or local code paths.

### How it was tested
- No-network unit tests: the Pegasus output is written in the `{page_content, metadata}` shape the loader expects; missing-key path raises a clear error.
- Live smoke test against the TwelveLabs API: a Marengo text embedding returns a **512-dim** vector. (Both via stdlib `unittest`; note your `.gitignore` excludes `tests/`, so the test file isn't committed.)
- The new module, config, and constants all import and `py_compile` cleanly.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
